### PR TITLE
If draggable column image fails to load, create canvas to show instead

### DIFF
--- a/packages/react-data-grid-addons/src/draggable/DraggableHeaderCell.js
+++ b/packages/react-data-grid-addons/src/draggable/DraggableHeaderCell.js
@@ -8,10 +8,25 @@ class DraggableHeaderCell extends Component {
   componentDidMount() {
     let connectDragPreview = this.props.connectDragPreview;
     let img = new Image();
-    img.src = './assets/images/drag_column_full.png';
     img.onload = function() {
       connectDragPreview(img);
     };
+    img.onerror = function() {
+      let canvas = document.createElement('canvas');
+      canvas.width = 150;
+      canvas.height = 200;
+      if (canvas.getContext) {
+        let ctx = canvas.getContext('2d');
+        ctx.fillStyle = '#eee';
+        ctx.fillRect(0, 0, 150, 35);
+        ctx.fillStyle = '#ddd';
+        ctx.fillRect(0, 35, 150, 1);
+        ctx.fillStyle = '#fff';
+        ctx.fillRect(0, 37, 150, 163);
+        img.src = canvas.toDataURL('image/png');
+      }
+    };
+    img.src = './assets/images/drag_column_full.png';
   }
 
   setScrollLeft(scrollLeft) {


### PR DESCRIPTION
Missing image causes bad dragging view.
This creates a canvas to show rather than a broken image/badly aligned column.