### PR TITLE
Enable meta keys to be used for editing

### DIFF
--- a/packages/react-data-grid/src/KeyboardHandlerMixin.js
+++ b/packages/react-data-grid/src/KeyboardHandlerMixin.js
@@ -2,6 +2,8 @@ let KeyboardHandlerMixin = {
   onKeyDown(e: SyntheticKeyboardEvent) {
     if (this.isCtrlKeyHeldDown(e)) {
       this.checkAndCall('onPressKeyWithCtrl', e);
+    } else if (this.isMetaKeyHeldDown(e)) {
+      this.checkAndCall('onPressKeyWithMeta', e);
     } else if (this.isKeyExplicitlyHandled(e.key)) {
       // break up individual keyPress events to have their own specific callbacks
       // this allows multiple mixins to listen to onKeyDown events and somewhat reduces methodName clashing
@@ -57,6 +59,10 @@ let KeyboardHandlerMixin = {
 
   isCtrlKeyHeldDown(e: SyntheticKeyboardEvent): boolean {
     return e.ctrlKey === true && e.key !== 'Control';
+  },
+
+  isMetaKeyHeldDown(e: SyntheticKeyboardEvent): boolean {
+    return e.metaKey && e.key !== 'Meta';
   },
 
   checkAndCall(methodName: string, args: any) {

--- a/packages/react-data-grid/src/ReactDataGrid.js
+++ b/packages/react-data-grid/src/ReactDataGrid.js
@@ -263,6 +263,14 @@ const ReactDataGrid = React.createClass({
   },
 
   onPressKeyWithCtrl(e: SyntheticKeyboardEvent) {
+    this.copyOrPasteByKeyPress(e);
+  },
+
+  onPressKeyWithMeta(e: SyntheticKeyboardEvent) {
+    this.copyOrPasteByKeyPress(e);
+  },
+
+  copyOrPasteByKeyPress(e: SyntheticKeyboardEvent) {
     let keys = {
       KeyCode_c: 99,
       KeyCode_C: 67,


### PR DESCRIPTION
Previously only ctrl was available - now cmd is available to be used for copy and paste